### PR TITLE
🧹 [Code Health] Remove unused `getAccessory` method

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -496,10 +496,6 @@ export class HaierEvoPlatform {
     return this.validatedConfig;
   }
 
-  public getAccessory(deviceId: string): HaierEvoAccessory | undefined {
-    return this.accessories.get(deviceId);
-  }
-
   public destroy(): void {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);


### PR DESCRIPTION
🎯 **What:** Removed the unused `getAccessory` method from `src/platform.ts`.
💡 **Why:** The `getAccessory` method is not used anywhere in the project. Removing it improves the maintainability and readability of the codebase by eliminating dead code.
✅ **Verification:** I successfully ran `npm run build`, `npm run lint`, and `npm run test` to verify that the code compiles, passes linting, and all tests pass without errors.
✨ **Result:** The codebase is cleaner and has less dead code, reducing confusion for future maintenance.

---
*PR created automatically by Jules for task [129777370546593141](https://jules.google.com/task/129777370546593141) started by @kulikovav*