### PR TITLE
🧹 Refactor: Remove unused removeDevice method

### DIFF
--- a/src/haier-api.ts
+++ b/src/haier-api.ts
@@ -2177,10 +2177,6 @@ export class HaierAPI extends EventEmitter {
     this.devices.set(device.device_id, device);
   }
 
-  removeDevice(deviceId: string): void {
-    this.devices.delete(deviceId);
-  }
-
   // Rate limiting and retry methods
   private async executeWithRateLimit<T>(
     requestFn: () => Promise<T>,


### PR DESCRIPTION
🎯 **What:** Removed the unused `removeDevice` method from the `HaierAPI` class in `src/haier-api.ts`.
💡 **Why:** The method was verified to be unused across the codebase. Removing it reduces dead code and improves maintainability.
✅ **Verification:** Ran `npm test` successfully. Verified that no functionality was broken.
✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [14226682268976687240](https://jules.google.com/task/14226682268976687240) started by @kulikovav*