### PR TITLE
fix: Nullify ws in disconnect()

### DIFF
--- a/src/haier-api.ts
+++ b/src/haier-api.ts
@@ -2019,8 +2019,8 @@ export class HaierAPI extends EventEmitter {
       } catch {
         // Swallow close errors so cleanup always proceeds
       }
-      this.ws = null;
     }
+    this.ws = null;
 
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);

--- a/tests/integration/websocket-lifecycle.test.ts
+++ b/tests/integration/websocket-lifecycle.test.ts
@@ -92,7 +92,7 @@ describe('HaierAPI WebSocket lifecycle', () => {
   // -------------------------------------------------------------------
 
   describe('Timer management', () => {
-    test('disconnect() clears reconnectTimer, heartbeatTimer, statusRequestTimer', () => {
+    test('disconnect() clears reconnectTimer, heartbeatTimer, statusRequestTimer and sets ws to null', () => {
       const a = api as any;
       const ws = createControlledWs();
       a.ws = ws;
@@ -110,13 +110,11 @@ describe('HaierAPI WebSocket lifecycle', () => {
 
       api.disconnect();
 
-      // disconnect clears timers but does NOT set ws to null (current behavior)
       expect(a.reconnectTimer).toBeNull();
       expect(a.heartbeatTimer).toBeNull();
       expect(a.statusRequestTimer).toBeNull();
       expect(a.isConnected).toBe(false);
-      // ws is NOT nulled in disconnect() (only in disconnectWebSocket())
-      // This is a bug to fix in the refactoring
+      expect(a.ws).toBeNull();
     });
 
     test('disconnectWebSocket() sets ws to null', () => {


### PR DESCRIPTION
Fixes the issue where `disconnect()` method does not null out `ws` currently; it only clears timers. This is noted as a bug to fix during refactoring.
It does so by moving `this.ws = null` outside the `if (this.ws) { ... }` block to ensure it's nulled unconditionally. Updated tests and removed outdated comments.

---
*PR created automatically by Jules for task [13246038261501708228](https://jules.google.com/task/13246038261501708228) started by @kulikovav*