### PR TITLE
🔒 Redact sensitive fields (password, refreshToken) in debug logs

### DIFF
--- a/src/haier-api.ts
+++ b/src/haier-api.ts
@@ -225,7 +225,17 @@ export class HaierAPI extends EventEmitter {
             'Content-Type': config.headers['Content-Type']
           });
           if (config.data) {
-            this.log.debug('Request body:', JSON.stringify(config.data, null, 2));
+            let dataToLog = config.data;
+            if (typeof config.data === 'object' && config.data !== null) {
+              dataToLog = { ...config.data };
+              if ('password' in dataToLog) {
+                dataToLog.password = '***';
+              }
+              if ('refreshToken' in dataToLog) {
+                dataToLog.refreshToken = '***';
+              }
+            }
+            this.log.debug('Request body:', JSON.stringify(dataToLog, null, 2));
           }
         }
 


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability where sensitive data (such as user passwords) could be logged in plain text when debug logs are enabled during API authentication requests.
⚠️ **Risk:** If a user enables debug mode, their password for the Haier account could be exposed in their homebridge logs. This could potentially allow unauthorized access if the logs are shared or compromised.
🛡️ **Solution:** The log interceptor now shallow-copies the request payload, explicitly looking for the `password` and `refreshToken` keys, and replacing their values with `***` before logging. This ensures sensitive credentials do not leak into output streams while preserving functional visibility.

---
*PR created automatically by Jules for task [12432266154443529303](https://jules.google.com/task/12432266154443529303) started by @kulikovav*