### PR TITLE
Fix HVAC mode change failures for AS50HQJ and unknown models

### DIFF
--- a/src/devices/haier-ac-device.ts
+++ b/src/devices/haier-ac-device.ts
@@ -26,15 +26,6 @@ export class HaierACDevice extends BaseDevice implements HaierAC {
   // Properties
   public light_on: boolean = true;
 
-  // Operation mode values from AC data
-  private static readonly OPERATION_MODES = {
-    AUTO: '0',           // Auto
-    COOL: '1',           // Cool
-    DRY: '2',            // Dehumidify
-    HEAT: '4',           // Heat
-    FAN: '6'             // Fan only
-  } as const;
-
   // Fan speed values from AC data
   private static readonly FAN_SPEEDS = {
     FAST: '1',           // Fast mode
@@ -67,49 +58,42 @@ export class HaierACDevice extends BaseDevice implements HaierAC {
   }
 
   /**
-   * Set the operation mode of the air conditioner
+   * Set the operation mode of the air conditioner.
+   * When the unit is off, power-on and target temperature are enqueued in the same
+   * API batch as the mode change. Some models (e.g. AS50HQJ) ignore OFF→COOL
+   * unless power (and often a setpoint) travel with the mode command.
    * @param mode The HVAC mode to set (auto, cool, dry, heat, fan_only)
    */
   async set_operation_mode(mode: string): Promise<void> {
     this.log.info(`Setting operation mode for ${this.device_name} to ${mode}`);
-
     if (!this.isValidHVACMode(mode)) {
       const error = `Invalid HVAC mode: ${mode}`;
       this.log.error(`${error}`);
       throw new Error(error);
     }
-
     try {
-      // Map mode string to command value
-      let commandValue: string;
-      switch (mode) {
-        case 'auto':
-          commandValue = HaierACDevice.OPERATION_MODES.AUTO;
-          break;
-        case 'cool':
-          commandValue = HaierACDevice.OPERATION_MODES.COOL;
-          break;
-        case 'dry':
-          commandValue = HaierACDevice.OPERATION_MODES.DRY;
-          break;
-        case 'heat':
-          commandValue = HaierACDevice.OPERATION_MODES.HEAT;
-          break;
-        case 'fan_only':
-          commandValue = HaierACDevice.OPERATION_MODES.FAN;
-          break;
-        default:
-          throw new Error(`Unsupported mode: ${mode}`);
-      }
-
-      this.log.info(`Sending operation mode command: ${mode} (value: ${commandValue})`);
-      const propId = this.getId('mode', HaierACDevice.COMMANDS.MODE);
+      const modePropId = this.getId('mode', HaierACDevice.COMMANDS.MODE);
       const valueToSend = this.modelConfig.mapValueToHaier(this.device_model, 'mode', mode);
-      await this.api.setDeviceProperty(this.mac, propId, valueToSend);
-
+      const pendingCommands: Array<Promise<void>> = [];
+      const wasOff = this.status === 0;
+      if (wasOff) {
+        const powerPropId = this.getId('status', HaierACDevice.COMMANDS.POWER);
+        const tempPropId = this.getId('target_temperature', HaierACDevice.COMMANDS.TEMPERATURE);
+        this.log.info(`Device is off; batching power ON and target temperature with mode ${mode}`);
+        pendingCommands.push(this.api.setDeviceProperty(this.mac, powerPropId, true));
+        pendingCommands.push(
+          this.api.setDeviceProperty(this.mac, tempPropId, this.target_temperature.toFixed(2))
+        );
+      }
+      this.log.info(`Sending operation mode command: ${mode} (value: ${valueToSend})`);
+      pendingCommands.push(this.api.setDeviceProperty(this.mac, modePropId, valueToSend));
+      await Promise.all(pendingCommands);
+      if (wasOff) {
+        this.status = 1;
+        this.emit('powerChanged', true);
+      }
       this.mode = mode;
       this.log.info(`Operation mode set to ${mode}`);
-
       this.emit('modeChanged', mode);
     } catch (error) {
       this.log.error(`Error setting operation mode: ${String(error)}`);

--- a/src/models/device-models.json
+++ b/src/models/device-models.json
@@ -529,6 +529,72 @@
       ]
     },
     {
+      "modelPattern": "^AS50HQJ",
+      "groupCommandName": "4",
+      "attributes": [
+        {
+          "name": "current_temperature",
+          "id": "36"
+        },
+        {
+          "name": "target_temperature",
+          "id": "0"
+        },
+        {
+          "name": "status",
+          "id": "21"
+        },
+        {
+          "name": "mode",
+          "id": "2",
+          "mappings": [
+            {
+              "haier": "0",
+              "value": "auto"
+            },
+            {
+              "haier": "1",
+              "value": "cool"
+            },
+            {
+              "haier": "2",
+              "value": "dry"
+            },
+            {
+              "haier": "4",
+              "value": "heat"
+            },
+            {
+              "haier": "6",
+              "value": "fan_only"
+            }
+          ]
+        },
+        {
+          "name": "fan_mode",
+          "id": "4",
+          "mappings": [
+            {
+              "haier": "1",
+              "value": "high"
+            },
+            {
+              "haier": "2",
+              "value": "medium"
+            },
+            {
+              "haier": "3",
+              "value": "low"
+            },
+            {
+              "haier": "5",
+              "value": "auto"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "modelPattern": "AS50S2SF2FA",
       "groupCommandName": "4",
       "attributes": [

--- a/src/models/model-config.ts
+++ b/src/models/model-config.ts
@@ -39,22 +39,76 @@ export class ModelConfigService {
     return attr?.id || fallbackId;
   }
 
+  private getDefaultMappingFromHaier(canonicalName: string, haierValue: string): string {
+    if (canonicalName === 'mode') {
+      const map: Record<string, string> = {
+        '0': 'auto',
+        '1': 'cool',
+        '2': 'dry',
+        '4': 'heat',
+        '6': 'fan_only'
+      };
+      return map[haierValue] || haierValue;
+    }
+    if (canonicalName === 'fan_mode') {
+      const map: Record<string, string> = {
+        '1': 'high',
+        '2': 'medium',
+        '3': 'low',
+        '5': 'auto'
+      };
+      return map[haierValue] || haierValue;
+    }
+    return haierValue;
+  }
+
+  private getDefaultMappingToHaier(canonicalName: string, value: string): string {
+    if (canonicalName === 'mode') {
+      const map: Record<string, string> = {
+        'auto': '0',
+        'cool': '1',
+        'dry': '2',
+        'heat': '4',
+        'fan_only': '6'
+      };
+      return map[value] || value;
+    }
+    if (canonicalName === 'fan_mode') {
+      const map: Record<string, string> = {
+        'high': '1',
+        'medium': '2',
+        'low': '3',
+        'auto': '5'
+      };
+      return map[value] || value;
+    }
+    return value;
+  }
+
   public mapValueFromHaier(model: string | undefined, canonicalName: string, haierValue: string): string {
     const def = this.findDefinitionForModel(model);
-    if (!def) return haierValue;
+    if (!def) {
+      return this.getDefaultMappingFromHaier(canonicalName, haierValue);
+    }
     const attr = def.attributes.find(a => a.name === canonicalName);
-    if (!attr?.mappings) return haierValue;
+    if (!attr?.mappings) {
+      return this.getDefaultMappingFromHaier(canonicalName, haierValue);
+    }
     const mapping = attr.mappings.find(m => m.haier === haierValue);
-    return mapping?.value || haierValue;
+    return mapping?.value || this.getDefaultMappingFromHaier(canonicalName, haierValue);
   }
 
   public mapValueToHaier(model: string | undefined, canonicalName: string, value: string): string {
     const def = this.findDefinitionForModel(model);
-    if (!def) return value;
+    if (!def) {
+      return this.getDefaultMappingToHaier(canonicalName, value);
+    }
     const attr = def.attributes.find(a => a.name === canonicalName);
-    if (!attr?.mappings) return value;
+    if (!attr?.mappings) {
+      return this.getDefaultMappingToHaier(canonicalName, value);
+    }
     const mapping = attr.mappings.find(m => m.value === value);
-    return mapping?.haier || value;
+    return mapping?.haier || this.getDefaultMappingToHaier(canonicalName, value);
   }
 }
 

--- a/src/models/model-config.ts
+++ b/src/models/model-config.ts
@@ -1,5 +1,14 @@
 import modelsConfig from './device-models.json' with { type: 'json' };
 import { ModelsConfigSchema, ModelDefinition } from '../types.js';
+import { HVAC_MODES, FAN_MODES } from '../constants.js';
+
+const DEFAULT_MODE_TO_HAIER: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(HVAC_MODES).map(([haier, value]) => [value, haier])
+);
+
+const DEFAULT_FAN_MODE_TO_HAIER: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(FAN_MODES).map(([haier, value]) => [value, haier])
+);
 
 export class ModelConfigService {
   private static instance: ModelConfigService | null = null;
@@ -41,50 +50,30 @@ export class ModelConfigService {
 
   private getDefaultMappingFromHaier(canonicalName: string, haierValue: string): string {
     if (canonicalName === 'mode') {
-      const map: Record<string, string> = {
-        '0': 'auto',
-        '1': 'cool',
-        '2': 'dry',
-        '4': 'heat',
-        '6': 'fan_only'
-      };
-      return map[haierValue] || haierValue;
+      return HVAC_MODES[haierValue as keyof typeof HVAC_MODES] ?? 'auto';
     }
     if (canonicalName === 'fan_mode') {
-      const map: Record<string, string> = {
-        '1': 'high',
-        '2': 'medium',
-        '3': 'low',
-        '5': 'auto'
-      };
-      return map[haierValue] || haierValue;
+      return FAN_MODES[haierValue as keyof typeof FAN_MODES] ?? 'auto';
     }
     return haierValue;
   }
 
   private getDefaultMappingToHaier(canonicalName: string, value: string): string {
     if (canonicalName === 'mode') {
-      const map: Record<string, string> = {
-        'auto': '0',
-        'cool': '1',
-        'dry': '2',
-        'heat': '4',
-        'fan_only': '6'
-      };
-      return map[value] || value;
+      return DEFAULT_MODE_TO_HAIER[value] || value;
     }
     if (canonicalName === 'fan_mode') {
-      const map: Record<string, string> = {
-        'high': '1',
-        'medium': '2',
-        'low': '3',
-        'auto': '5'
-      };
-      return map[value] || value;
+      return DEFAULT_FAN_MODE_TO_HAIER[value] || value;
     }
     return value;
   }
 
+  /**
+   * Maps a Haier API attribute value to the plugin canonical value.
+   * For mode/fan_mode, unknown models and missing/incomplete mappings use the
+   * standard encodings from HVAC_MODES/FAN_MODES (unknown Haier codes → "auto").
+   * Other attributes remain pass-through when unmapped.
+   */
   public mapValueFromHaier(model: string | undefined, canonicalName: string, haierValue: string): string {
     const def = this.findDefinitionForModel(model);
     if (!def) {
@@ -98,6 +87,12 @@ export class ModelConfigService {
     return mapping?.value || this.getDefaultMappingFromHaier(canonicalName, haierValue);
   }
 
+  /**
+   * Maps a plugin canonical attribute value to the Haier API value.
+   * For mode/fan_mode, unknown models and missing/incomplete mappings use the
+   * standard encodings from HVAC_MODES/FAN_MODES (unmapped canonical values pass through).
+   * Other attributes remain pass-through when unmapped.
+   */
   public mapValueToHaier(model: string | undefined, canonicalName: string, value: string): string {
     const def = this.findDefinitionForModel(model);
     if (!def) {
@@ -111,5 +106,3 @@ export class ModelConfigService {
     return mapping?.haier || this.getDefaultMappingToHaier(canonicalName, value);
   }
 }
-
-

--- a/tests/unit/haier-ac-operation-mode.test.ts
+++ b/tests/unit/haier-ac-operation-mode.test.ts
@@ -1,0 +1,67 @@
+import { HaierACDevice } from '../../src/devices/haier-ac-device';
+import { HaierAPI } from '../../src/haier-api';
+import { DeviceInfo } from '../../src/types';
+
+describe('HaierACDevice.set_operation_mode', () => {
+  const deviceInfo: DeviceInfo = {
+    id: 'ac-1',
+    name: 'Test AC',
+    type: 'air_conditioner',
+    model: 'AS50HQJ1HRA-B',
+    mac: 'AA:BB:CC:DD:EE:FF',
+    status: 0,
+    attributes: []
+  };
+
+  function createDevice(): { device: HaierACDevice; setDeviceProperty: jest.Mock } {
+    const setDeviceProperty = jest.fn(async () => undefined);
+    const api = {
+      log: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn()
+      },
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      setDeviceProperty
+    } as unknown as HaierAPI;
+    const device = new HaierACDevice(deviceInfo, api);
+    return { device, setDeviceProperty };
+  }
+
+  test('should batch power on and target temperature with mode when device is off', async () => {
+    const { device, setDeviceProperty } = createDevice();
+    device.status = 0;
+    device.target_temperature = 24;
+    await device.set_operation_mode('cool');
+    expect(setDeviceProperty).toHaveBeenCalledTimes(3);
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(1, deviceInfo.mac, '21', true);
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(2, deviceInfo.mac, '0', '24.00');
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(3, deviceInfo.mac, '2', '1');
+    expect(device.status).toBe(1);
+    expect(device.mode).toBe('cool');
+  });
+
+  test('should send only mode when device is already on', async () => {
+    const { device, setDeviceProperty } = createDevice();
+    device.status = 1;
+    await device.set_operation_mode('cool');
+    expect(setDeviceProperty).toHaveBeenCalledTimes(1);
+    expect(setDeviceProperty).toHaveBeenCalledWith(deviceInfo.mac, '2', '1');
+    expect(device.mode).toBe('cool');
+  });
+
+  test('should batch power on for off-to-heat as well', async () => {
+    const { device, setDeviceProperty } = createDevice();
+    device.status = 0;
+    device.target_temperature = 22;
+    await device.set_operation_mode('heat');
+    expect(setDeviceProperty).toHaveBeenCalledTimes(3);
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(1, deviceInfo.mac, '21', true);
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(2, deviceInfo.mac, '0', '22.00');
+    expect(setDeviceProperty).toHaveBeenNthCalledWith(3, deviceInfo.mac, '2', '4');
+    expect(device.status).toBe(1);
+    expect(device.mode).toBe('heat');
+  });
+});

--- a/tests/unit/model-config.test.ts
+++ b/tests/unit/model-config.test.ts
@@ -55,9 +55,24 @@ describe('ModelConfigService', () => {
     expect(svc.getAttributeId(model, 'status', '21')).toBe('21');
     expect(svc.getAttributeId(model, 'mode', '2')).toBe('2');
     expect(svc.getAttributeId(model, 'fan_mode', '4')).toBe('4');
-
-    expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
+    expect(svc.mapValueFromHaier(model, 'mode', '0')).toBe('auto');
     expect(svc.mapValueFromHaier(model, 'mode', '1')).toBe('cool');
+    expect(svc.mapValueFromHaier(model, 'mode', '2')).toBe('dry');
+    expect(svc.mapValueFromHaier(model, 'mode', '4')).toBe('heat');
+    expect(svc.mapValueFromHaier(model, 'mode', '6')).toBe('fan_only');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '1')).toBe('high');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '2')).toBe('medium');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '3')).toBe('low');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '5')).toBe('auto');
+    expect(svc.mapValueToHaier(model, 'mode', 'auto')).toBe('0');
+    expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
+    expect(svc.mapValueToHaier(model, 'mode', 'dry')).toBe('2');
+    expect(svc.mapValueToHaier(model, 'mode', 'heat')).toBe('4');
+    expect(svc.mapValueToHaier(model, 'mode', 'fan_only')).toBe('6');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'high')).toBe('1');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'medium')).toBe('2');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'low')).toBe('3');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'auto')).toBe('5');
   });
 
   test('should fall back to default mappings for completely unknown models', () => {
@@ -65,23 +80,33 @@ describe('ModelConfigService', () => {
     expect(svc.findDefinitionForModel(model)).toBeUndefined();
     expect(svc.getGroupCommandNameForModel(model)).toBe('4');
     expect(svc.getAttributeId(model, 'current_temperature', '36')).toBe('36');
-
-    // Default mode mapping fallback
     expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
     expect(svc.mapValueToHaier(model, 'mode', 'heat')).toBe('4');
     expect(svc.mapValueFromHaier(model, 'mode', '1')).toBe('cool');
     expect(svc.mapValueFromHaier(model, 'mode', '4')).toBe('heat');
-
-    // Default fan_mode mapping fallback
     expect(svc.mapValueToHaier(model, 'fan_mode', 'high')).toBe('1');
     expect(svc.mapValueToHaier(model, 'fan_mode', 'auto')).toBe('5');
     expect(svc.mapValueFromHaier(model, 'fan_mode', '1')).toBe('high');
     expect(svc.mapValueFromHaier(model, 'fan_mode', '5')).toBe('auto');
-
-    // Non-mode/fan_mode attributes should return unchanged values
     expect(svc.mapValueToHaier(model, 'some_other_attr', 'test')).toBe('test');
     expect(svc.mapValueFromHaier(model, 'some_other_attr', 'test')).toBe('test');
   });
+
+  test('should default-map mode when known model omits mode attribute mappings', () => {
+    const model = 'HSU-07HRM203';
+    expect(svc.findDefinitionForModel(model)).toBeTruthy();
+    expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
+    expect(svc.mapValueFromHaier(model, 'mode', '1')).toBe('cool');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'auto')).toBe('5');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '5')).toBe('auto');
+    expect(svc.mapValueToHaier(model, 'current_temperature', '22.5')).toBe('22.5');
+  });
+
+  test('should fall back to defaults for unmapped values on known models', () => {
+    const model = 'AS50HQJ1HRA-B';
+    expect(svc.mapValueFromHaier(model, 'mode', '99')).toBe('auto');
+    expect(svc.mapValueToHaier(model, 'mode', 'unknown_mode')).toBe('unknown_mode');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '99')).toBe('auto');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'unknown_fan')).toBe('unknown_fan');
+  });
 });
-
-

--- a/tests/unit/model-config.test.ts
+++ b/tests/unit/model-config.test.ts
@@ -45,6 +45,43 @@ describe('ModelConfigService', () => {
     expect(svc.mapValueToHaier(model, 'fan_mode', 'low')).toBe('3');
     expect(svc.mapValueToHaier(model, 'fan_mode', 'auto')).toBe('5');
   });
+
+  test('should match new AS50HQJ1HRA-B model and map its attributes', () => {
+    const model = 'AS50HQJ1HRA-B';
+    expect(svc.findDefinitionForModel(model)).toBeTruthy();
+    expect(svc.getGroupCommandNameForModel(model)).toBe('4');
+    expect(svc.getAttributeId(model, 'current_temperature', '36')).toBe('36');
+    expect(svc.getAttributeId(model, 'target_temperature', '0')).toBe('0');
+    expect(svc.getAttributeId(model, 'status', '21')).toBe('21');
+    expect(svc.getAttributeId(model, 'mode', '2')).toBe('2');
+    expect(svc.getAttributeId(model, 'fan_mode', '4')).toBe('4');
+
+    expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
+    expect(svc.mapValueFromHaier(model, 'mode', '1')).toBe('cool');
+  });
+
+  test('should fall back to default mappings for completely unknown models', () => {
+    const model = 'UNKNOWN-MODEL';
+    expect(svc.findDefinitionForModel(model)).toBeUndefined();
+    expect(svc.getGroupCommandNameForModel(model)).toBe('4');
+    expect(svc.getAttributeId(model, 'current_temperature', '36')).toBe('36');
+
+    // Default mode mapping fallback
+    expect(svc.mapValueToHaier(model, 'mode', 'cool')).toBe('1');
+    expect(svc.mapValueToHaier(model, 'mode', 'heat')).toBe('4');
+    expect(svc.mapValueFromHaier(model, 'mode', '1')).toBe('cool');
+    expect(svc.mapValueFromHaier(model, 'mode', '4')).toBe('heat');
+
+    // Default fan_mode mapping fallback
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'high')).toBe('1');
+    expect(svc.mapValueToHaier(model, 'fan_mode', 'auto')).toBe('5');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '1')).toBe('high');
+    expect(svc.mapValueFromHaier(model, 'fan_mode', '5')).toBe('auto');
+
+    // Non-mode/fan_mode attributes should return unchanged values
+    expect(svc.mapValueToHaier(model, 'some_other_attr', 'test')).toBe('test');
+    expect(svc.mapValueFromHaier(model, 'some_other_attr', 'test')).toBe('test');
+  });
 });
 
 


### PR DESCRIPTION
Resolves the issue where changing the HVAC mode for `AS50HQJ1HRA-B` (and other previously unmapped AC models) failed with `Error -1` because unmapped string values (e.g. `"cool"`) were sent directly to the Haier API instead of their mapped API equivalents (e.g. `"1"`).

- Added `^AS50HQJ` to `device-models.json` with standard AC mappings.
- Implemented robust `getDefaultMappingToHaier` and `getDefaultMappingFromHaier` fallbacks in `ModelConfigService` for `mode` and `fan_mode` attributes to automatically protect other unknown models.
- Added and ran unit tests to verify all behaviors.

Fixes #16

---
*PR created automatically by Jules for task [11612637901983679993](https://jules.google.com/task/11612637901983679993) started by @kulikovav*