### PR TITLE
ci: add beta npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies

--- a/.github/workflows/npm-publish-beta.yml
+++ b/.github/workflows/npm-publish-beta.yml
@@ -1,0 +1,137 @@
+name: Node.js Package (Beta)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Prerelease bump type'
+        required: true
+        default: 'prerelease'
+        type: choice
+        options:
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linting
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Run standalone device tests
+        run: node test-devices.js
+
+      - name: Run standalone rate limiting tests
+        run: node test-rate-limiting.js
+
+  publish-npm-beta:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Bump beta version
+        run: |
+          VERSION=$(npm version ${{ github.event.inputs.version }} --preid=beta --no-git-tag-version | sed 's/^"//;s/"$//' | sed 's/^v//')
+
+          if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+            echo "Invalid beta version format: $VERSION"
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Commit version bump
+        run: |
+          git add package.json package-lock.json
+          git commit -m "Bump version to ${{ env.VERSION }}"
+
+      - name: Create tag
+        run: |
+          git tag -a "v${{ env.VERSION }}" -m "Beta release version ${{ env.VERSION }}"
+
+      - name: Push changes and tags
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git push origin HEAD:${GITHUB_REF#refs/heads/}
+          git push origin "v${{ env.VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .npmrc file for authentication
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          echo "registry=https://registry.npmjs.org/" >> .npmrc
+          echo "always-auth=true" >> .npmrc
+
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "::error::NPM_TOKEN is not set. Please add it to your repository secrets."
+            exit 1
+          else
+            echo "NPM_TOKEN is set and will be used for authentication"
+          fi
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm with beta tag
+        run: npm publish --access public --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Output publishing result
+        run: |
+          echo "Published beta to npm: https://www.npmjs.com/package/homebridge-haier-evo"
+          echo "Version: ${{ env.VERSION }}"
+          echo "Install with: npm install homebridge-haier-evo@beta"
+
+      - name: Create GitHub Prerelease
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: Beta v${{ env.VERSION }}
+          draft: false
+          prerelease: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Maintainers can publish prerelease builds to npm under the `beta` dist-tag without moving `latest`, via a manual workflow that bumps a `-beta.N` version, publishes, and opens a GitHub prerelease.

Install with `npm install homebridge-haier-evo@beta`. Uses Node.js 24 and the existing `NPM_TOKEN` secret.

## Test plan
- [ ] Run **Node.js Package (Beta)** from Actions with `prerelease` on a non-production branch
- [ ] Confirm the published version matches `*-beta.N` and `npm view homebridge-haier-evo dist-tags` shows `beta`
- [ ] Confirm `latest` is unchanged and a GitHub prerelease was created

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Composer-000000)
