### PR TITLE
Allow unknown top-level fields in device config validation

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -55,7 +55,7 @@ export const deviceConfigResponseSchema = z.object({
   power: z.object({
     value: z.object({ name: z.string() }).optional(),
   }).optional(),
-}).strict();
+}).passthrough();
 
 export const deviceStatusEventSchema = z.object({
   event: z.string(),

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -253,13 +253,13 @@ describe('parseDeviceConfig', () => {
     expect(parseDeviceConfig([])).toBeNull();
   });
 
-  it('should return null if unexpected extra properties are present (due to .strict())', () => {
+  it('should preserve unexpected top-level properties from API responses', () => {
     const raw = {
       info: { model: 'model-123' },
-      extra: 'this should fail',
+      extra: 'kept for forward-compatible API responses',
     };
     const result = parseDeviceConfig(raw);
-    expect(result).toBeNull();
+    expect(result).toEqual(raw);
   });
 
   it('should strip unknown nested properties on non-strict nested schemas', () => {


### PR DESCRIPTION
### Motivation
- The device config validator previously used `.strict()` which rejected responses with new top-level API fields and caused valid responses to be treated as invalid; making the schema forward-compatible prevents losing parsed data when the API adds properties.

### Description
- Change `deviceConfigResponseSchema` from `.strict()` to `.passthrough()` in `src/validation.ts` and update `tests/unit/validation.test.ts` to assert that unexpected top-level properties are preserved.

### Testing
- Ran the unit tests and full test suite with `npm test -- --runInBand` and executed the build with `npm run build`, and all tests/build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a765a3fe7b4832c912d7e70f06b671c)