### PR TITLE
Fix changelog update in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -106,15 +106,27 @@ jobs:
             # Create a temporary file
             TEMP_FILE=$(mktemp)
 
-            CURRENT_VERSION=$(git describe --abbrev=0 --tags)
+            RELEASE_TAG="v${{ env.VERSION }}"
+            if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+              PREVIOUS_VERSION=$(git describe --abbrev=0 --tags "${RELEASE_TAG}^" 2>/dev/null || true)
+            else
+              PREVIOUS_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || true)
+            fi
+
+            if [ -n "$PREVIOUS_VERSION" ]; then
+              RELEASE_NOTES=$(git log --pretty=format:"- %s" "$PREVIOUS_VERSION..HEAD" | grep -Ev "(Merge pull request|Merge branch|Bump version)" || true)
+            else
+              RELEASE_NOTES=$(git log --pretty=format:"- %s" | grep -Ev "(Merge pull request|Merge branch|Bump version)" || true)
+            fi
 
             # Process the changelog
             while IFS= read -r line; do
               if [[ "$line" == "## [Unreleased]" ]]; then
                 # Add the new version header
                 echo "## [${{ env.VERSION }}] - $CURRENT_DATE" >> "$TEMP_FILE"
-                # Generate release notes from commit messages since previous version
-                git log --pretty=format:"- %s" $CURRENT_VERSION..HEAD | egrep -v "(Merge pull request|Merge branch|Bump version)" >> "$TEMP_FILE"
+                if [ -n "$RELEASE_NOTES" ]; then
+                  echo "$RELEASE_NOTES" >> "$TEMP_FILE"
+                fi
                 echo "" >> "$TEMP_FILE"
                 echo "## [Unreleased]" >> "$TEMP_FILE"
               else

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -108,10 +108,20 @@ jobs:
 
             RELEASE_TAG="v${{ env.VERSION }}"
             if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
-              PREVIOUS_VERSION=$(git describe --abbrev=0 --tags "${RELEASE_TAG}^" 2>/dev/null || true)
+              TAG_REF="${RELEASE_TAG}^"
             else
-              PREVIOUS_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || true)
+              TAG_REF="HEAD"
             fi
+
+            # Find the previous stable release, skipping prerelease tags (e.g. beta)
+            # so that commits from beta releases are included in the changelog
+            PREVIOUS_VERSION=""
+            for TAG in $(git tag --sort=-version:refname); do
+              if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && git merge-base --is-ancestor "$TAG" "$TAG_REF" 2>/dev/null; then
+                PREVIOUS_VERSION="$TAG"
+                break
+              fi
+            done
 
             if [ -n "$PREVIOUS_VERSION" ]; then
               RELEASE_NOTES=$(git log --pretty=format:"- %s" "$PREVIOUS_VERSION..HEAD" | grep -Ev "(Merge pull request|Merge branch|Bump version)" || true)


### PR DESCRIPTION
### Motivation
- The `Update changelog` step in the `npm-publish` workflow could fail when the release tag already existed or when generating release notes produced no matching commits, causing the CI job to exit with a non-zero status. 
- Make the changelog update robust against missing previous tags and empty `git log`/`grep` results so releases don't fail unexpectedly.

### Description
- Replace the fragile `CURRENT_VERSION=$(git describe --abbrev=0 --tags)` approach with a `RELEASE_TAG`/`PREVIOUS_VERSION` lookup that safely handles existing tags and missing previous tags in `/.github/workflows/npm-publish.yml`.
- Build `RELEASE_NOTES` using `git log` and `grep -Ev` guarded with `|| true` to avoid pipeline failures when there are no matching commits. 
- Only append `RELEASE_NOTES` to the temporary changelog when it's non-empty, preserving the original `CHANGELOG.md` structure otherwise.

### Testing
- Verified the generated `Update changelog` script with `bash -n /tmp/update-changelog-step.sh`, which returned no syntax errors. 
- Ran `npm run build` to ensure the repository still builds (`tsc`), and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a765c7e6258832caa4f93922dbb7d1f)